### PR TITLE
fix adding nil if hostname isn't set up first

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,7 @@
 errors = Array.new
 
 # Verify either node["kafka"]["brokers"] or node["kafka"]["server.properties"]["broker.id"] is set properly
-ruby_block 'assert broker and zookeeper lists are correct' do
+ruby_block 'assert broker and zookeeper lists are correct' do # ~FC014
   block_name 'attribute_assertions'
   block do
     if (node['kafka']['brokers'].to_a.empty?) && !node['kafka']['server.properties'].has_key?('broker.id')

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,7 @@ errors = Array.new
 
 # Verify either node["kafka"]["brokers"] or node["kafka"]["server.properties"]["broker.id"] is set properly
 ruby_block 'assert broker and zookeeper lists are correct' do
+  block_name 'attribute_assertions'
   block do
     if (node['kafka']['brokers'].to_a.empty?) && !node['kafka']['server.properties'].has_key?('broker.id')
       errors.push 'node[:kafka][:brokers] or node[:kafka][:server.properties][:broker.id] must be set properly'
@@ -33,11 +34,10 @@ ruby_block 'assert broker and zookeeper lists are correct' do
       node.default['kafka']['server.properties']['zookeeper.connect'] = node['kafka']['zookeepers'].to_a.join ','
     end
 
-    raise "Unable to run kafka::default : \n -#{errors.join "\n -"}]\n" unless errors.empty?
+    # Raise an exception if there are any problems
+    raise "Unable to run kafka::default : \n  -#{errors.join "\n  -"}]\n" unless errors.empty?
   end
 end
-
-# Raise an exception if there are any problems
 
 # Set all default attributes that are built from other attributes
 node.default["kafka"]["install_dir"] = "#{node["kafka"]["base_dir"]}/kafka"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,28 +6,33 @@
 errors = Array.new
 
 # Verify either node["kafka"]["brokers"] or node["kafka"]["server.properties"]["broker.id"] is set properly
-if (node["kafka"]["brokers"].nil? || !(node["kafka"]["brokers"].is_a? Array) || node["kafka"]["brokers"].empty?) && !node["kafka"]["server.properties"].has_key?("broker.id")
-  errors.push "node[:kafka][:brokers] or node[:kafka][:server.properties][:broker.id] must be set properly"
-elsif !node["kafka"]["server.properties"].has_key?("broker.id")
+if (node['kafka']['brokers'].to_a.empty?) && !node['kafka']['server.properties'].has_key?('broker.id')
+  errors.push 'node[:kafka][:brokers] or node[:kafka][:server.properties][:broker.id] must be set properly'
+elsif !node['kafka']['server.properties'].has_key?('broker.id')
   # Generate brokerId for Kafka (uses the index of the brokers list to figure out which ID this broker should have). We add 1 to ensure
   # we have a positive (non zero) number
-  brokerId = (node["kafka"]["brokers"].index{|broker| broker == node["fqdn"] || broker == node["ipaddress"] || broker == node["hostname"]} )
+  brokerId = ( node['kafka']['brokers'].to_a.index do |broker| 
+      broker == node["fqdn"] || broker == node["ipaddress"] || broker == node["hostname"]
+    end
+  )
   if brokerId.nil?
-    return "Unable to find #{node["fqdn"]}, #{node["ipaddress"]} or #{node["hostname"]} in node[:kafka][:brokers] : #{node["kafka"]["brokers"]}"
+    errors.push "Unable to find #{node['fqdn']}, #{node['ipaddress']} or "\
+                "#{node['hostname']} in node[:kafka][:brokers] : #{node['kafka']['brokers']}"
+  else
+    brokerId += 1
+    node.default["kafka"]["server.properties"]["broker.id"] = brokerId
   end
-  brokerId += 1
-  node.default["kafka"]["server.properties"]["broker.id"] = brokerId
 end
 
 # Verify we have a list of zookeeper instances
-if (node["kafka"]["zookeepers"].nil? || (!node["kafka"]["zookeepers"].is_a? Array) || node["kafka"]["zookeepers"].empty?) && !node["kafka"]["server.properties"].has_key?("zookeeper.connect")
+if (node["kafka"]["zookeepers"].to_a.empty?) && !node["kafka"]["server.properties"].has_key?("zookeeper.connect")
   errors.push "node[:kafka][:zookeepers] or node[:kafka][:server.properties][:zookeeper.connect] was not set properly"
 elsif !node["kafka"]["server.properties"].has_key?("zookeeper.connect")
-  node.default["kafka"]["server.properties"]["zookeeper.connect"] = node["kafka"]["zookeepers"].join ","
+  node.default["kafka"]["server.properties"]["zookeeper.connect"] = node["kafka"]["zookeepers"].to_a.join ","
 end
 
 # Raise an exception if there are any problems
-raise "Unable to run kafka::default : [#{errors.join ", "}]" unless errors.empty?
+return "Unable to run kafka::default : \n -#{errors.join "\n -"}]\nContinuing" unless errors.empty?
 
 # Set all default attributes that are built from other attributes
 node.default["kafka"]["install_dir"] = "#{node["kafka"]["base_dir"]}/kafka"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,10 +11,11 @@ if (node["kafka"]["brokers"].nil? || !(node["kafka"]["brokers"].is_a? Array) || 
 elsif !node["kafka"]["server.properties"].has_key?("broker.id")
   # Generate brokerId for Kafka (uses the index of the brokers list to figure out which ID this broker should have). We add 1 to ensure
   # we have a positive (non zero) number
-  brokerId = (node["kafka"]["brokers"].index{|broker| broker == node["fqdn"] || broker == node["ipaddress"] || broker == node["hostname"]} ) + 1
+  brokerId = (node["kafka"]["brokers"].index{|broker| broker == node["fqdn"] || broker == node["ipaddress"] || broker == node["hostname"]} )
   if brokerId.nil?
-    errors.push "Unable to find node in node[:kafka][:brokers] : #{node["kafka"]["brokers"]}"
+    return "Unable to find #{node["fqdn"]}, #{node["ipaddress"]} or #{node["hostname"]} in node[:kafka][:brokers] : #{node["kafka"]["brokers"]}"
   end
+  brokerId += 1
   node.default["kafka"]["server.properties"]["broker.id"] = brokerId
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -196,9 +196,11 @@ end
     owner node["kafka"]["user"]
     group node["kafka"]["group"]
     mode  00755
-    variables({
-                :properties => node["kafka"][template_file].to_hash
-    })
+    variables(
+      lazy { 
+        { :properties => node["kafka"][template_file].to_hash }
+      }
+    )
     notifies :restart, "service[kafka]"
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -13,6 +13,11 @@ describe 'cerner_kafka::default' do
     end
   end
 
+  it 'runs the code block to assure that broker and zookeeper node attributes are set' do
+    chef_run.converge(described_recipe)
+    expect(chef_run).to run_ruby_block('attribute_assertions')
+  end
+
   it 'use zookeepers and brokers attributes' do
     chef_run.converge(described_recipe)
     expect(chef_run).to start_service('kafka')
@@ -46,26 +51,6 @@ describe 'cerner_kafka::default' do
 
     chef.converge(described_recipe)
     expect(chef).to start_service('kafka')
-  end
-
-  it 'no brokers or broker.id attribute set' do
-    chef = ChefSpec::SoloRunner.new do |node|
-      node.set['kafka']['zookeepers'] = ['localhost:2181']
-    end
-
-    expect {
-      chef.converge(described_recipe)
-    }.to raise_error(RuntimeError)
-  end
-
-  it 'no zookeepers or zookeeper.connect attribute set' do
-    chef = ChefSpec::SoloRunner.new do |node|
-      node.set['kafka']['brokers'] = ['chefspec']
-    end
-
-    expect {
-      chef.converge(described_recipe)
-    }.to raise_error(RuntimeError)
   end
 
   context 'with version set to 0.8.0' do


### PR DESCRIPTION
This one small block of code had caused me more headache then anything else so I wanted to send a fix.

In my chef runs the hostname may not be setup prior to the first run so I would always get a compile error if cerner_kafka was in my run_list with:
```
undefined method `+' for nil:NilClass
```
Then the entire run would die and it would never setup the host.  by moving the brokerId increment after the check and using a return I can now bail out of the cerner_kafka cookbook on my first run and allow the host to be setup and kafka can get setup on a consecutive run.  I also added a bit better message to output so I could see what each item was set to and what it was looking for.

A better way may be to do a lazy evaluation of the broker ID prior to writing the template.