### PR TITLE
add libraries to find broker id and zookeepers

### DIFF
--- a/libraries/config_helper.rb
+++ b/libraries/config_helper.rb
@@ -1,0 +1,60 @@
+def set_broker_id
+  if node['kafka']['server.properties'].key?('broker.id')
+    Chef::Log.info(
+      "broker hard set to #{node['kafka']['server.properties']['broker.id']} "\
+      'in server.properties node object'
+    )
+    return
+  end
+
+  brokers = Array(node['kafka']['brokers'])
+
+  if brokers.nil?
+    Chef::Log.error(
+      "node['kafka']['brokers'] or "\
+      "node['kafka']['server.properties']['broker.id'] must be set properly"
+    )
+  else
+    broker_id = brokers.index do |broker|
+      broker == node['fqdn'] ||
+      broker == node['ipaddress'] ||
+      broker == node['hostname']
+    end
+
+    if broker_id.nil?
+      Chef::Log.error("Unable to find #{node['fqdn']}, #{node['ipaddress']} or "\
+                      "#{node['hostname']} in node['kafka']['brokers'] : #{node['kafka']['brokers']}"
+                     )
+    else
+      node.default['kafka']['server.properties']['broker.id'] = broker_id + 1
+      Chef::Log.error("SET BROKER!! #{node['kafka']['server.properties']['broker.id']}")
+      return
+    end
+  end
+
+  raise 'Unable to run kafka::default unable to determine broker ID'
+end
+
+def set_zookeeper_connect
+  if node['kafka']['server.properties'].key?('zookeeper.connect')
+    Chef::Log.error(
+      "broker hard set to '#{node['kafka']['server.properties']['zookeeper.connect']}' "\
+      'in server.properties node object'
+    )
+    return
+  end
+
+  if node['kafka']['zookeepers'].nil?
+    Chef::Log.error(
+      "node['kafka']['zookeepers'] or "\
+      "node['kafka']['server.properties']['zookeepers.connect'] must be set properly"
+    )
+  else
+    zk_connect = Array(node['kafka']['zookeepers']).join ','
+    zk_connect += node['kafka']['zookeeper_chroot'] if node['kafka']['zookeeper_chroot']
+    node.default['kafka']['server.properties']['zookeeper.connect'] = zk_connect
+    return
+  end
+
+  raise 'Unable to run kafka::default unable to determine zookeeper hosts'
+end

--- a/libraries/config_helper.rb
+++ b/libraries/config_helper.rb
@@ -27,7 +27,7 @@ def set_broker_id
                      )
     else
       node.default['kafka']['server.properties']['broker.id'] = broker_id + 1
-      Chef::Log.error("SET BROKER!! #{node['kafka']['server.properties']['broker.id']}")
+      Chef::Log.debug("BROKER SET: #{node['kafka']['server.properties']['broker.id']}")
       return
     end
   end
@@ -45,7 +45,7 @@ def set_zookeeper_connect
   end
 
   if node['kafka']['zookeepers'].nil?
-    Chef::Log.error(
+    Chef::Log.info(
       "node['kafka']['zookeepers'] or "\
       "node['kafka']['server.properties']['zookeepers.connect'] must be set properly"
     )


### PR DESCRIPTION
I created this library code for a confluent-kafka cookbook based off your default recipe that we discussed at one point of moving to a library.  You should be able to replace the ruby_block with two calls to the functions in this library.

We are testing moving away from straight Kafka so I wouldn't be able to test it enough to actually implement, but didn't want you to miss out on fixing something we planned to at some point anyway.