### PR TITLE
separated user and group logic to another recipe

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -6,3 +6,4 @@ Nate Clevenger
 Henri Tremblay
 Pradeep Bhadani
 Bill Warner
+Austin Heiman

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,8 @@ maintainer        "Cerner Corp."
 maintainer_email  "Bryan.Baugher@cerner.com"
 license           "Apache 2.0"
 description       "Installs and configures a Kafka"
+issues_url        'https://github.com/cerner/cerner_kafka/issues'
+source_url        'https://github.com/cerner/cerner_kafka'
 
 depends 'java'
 depends 'ulimit'

--- a/recipes/_user_group.rb
+++ b/recipes/_user_group.rb
@@ -1,0 +1,23 @@
+# setup kafka group
+group node["kafka"]["group"] do
+  action :create
+end
+
+# setup kafka user
+user node["kafka"]["user"] do
+  comment "Kafka user"
+  uid node["kafka"]["uid"] if node["kafka"]["uid"]
+  gid node["kafka"]["group"]
+  shell "/bin/bash"
+  home "/home/#{node["kafka"]["user"]}"
+  supports :manage_home => true
+end
+
+# Configure kafka user
+template "/home/#{node["kafka"]["user"]}/.bash_profile" do
+  source  "bash_profile.erb"
+  owner node["kafka"]["user"]
+  group node["kafka"]["group"]
+  mode  00755
+  notifies :restart, "service[kafka]"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,29 +39,8 @@ log "Binary URL : #{node["kafka"]["binary_url"]}"
 include_recipe "java"
 include_recipe "ulimit"
 
-# setup kafka group
-group node["kafka"]["group"] do
-  action :create
-end
-
-# setup kafka user
-user node["kafka"]["user"] do
-  comment "Kafka user"
-  uid node["kafka"]["uid"] if node["kafka"]["uid"]
-  gid node["kafka"]["group"]
-  shell "/bin/bash"
-  home "/home/#{node["kafka"]["user"]}"
-  supports :manage_home => true
-end
-
-# Configure kafka user
-template "/home/#{node["kafka"]["user"]}/.bash_profile" do
-  source  "bash_profile.erb"
-  owner node["kafka"]["user"]
-  group node["kafka"]["group"]
-  mode  00755
-  notifies :restart, "service[kafka]"
-end
+# manage user and group
+include_recipe "cerner_kafka::_user_group"
 
 # Ensure the Kafka base directory exists
 directory node["kafka"]["base_dir"] do


### PR DESCRIPTION
This allows us to create the kafka user to own a log_dir created when we mount disks before the rest of the cerner_kafka logic.

example run_list:

```
recipe[cerner_kakfa::_user_group]
recipe[kafka_mount_disks]
recipe[cerner_kafka]
```