### PR TITLE
moved kafka user configuration back into default recipe

### DIFF
--- a/recipes/_user_group.rb
+++ b/recipes/_user_group.rb
@@ -12,12 +12,3 @@ user node["kafka"]["user"] do
   home "/home/#{node["kafka"]["user"]}"
   supports :manage_home => true
 end
-
-# Configure kafka user
-template "/home/#{node["kafka"]["user"]}/.bash_profile" do
-  source  "bash_profile.erb"
-  owner node["kafka"]["user"]
-  group node["kafka"]["group"]
-  mode  00755
-  notifies :restart, "service[kafka]"
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,6 +42,15 @@ include_recipe "ulimit"
 # manage user and group
 include_recipe "cerner_kafka::_user_group"
 
+# Configure kafka user
+template "/home/#{node["kafka"]["user"]}/.bash_profile" do
+  source  "bash_profile.erb"
+  owner node["kafka"]["user"]
+  group node["kafka"]["group"]
+  mode  00755
+  notifies :restart, "service[kafka]"
+end
+
 # Ensure the Kafka base directory exists
 directory node["kafka"]["base_dir"] do
   action :create

--- a/spec/user_group_spec.rb
+++ b/spec/user_group_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'cerner_kafka::_user_group' do
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+    end.converge(described_recipe)
+  end
+
+  it 'creates kafka user and group' do
+    expect(chef_run).to create_group('kafka')
+    expect(chef_run).to create_user('kafka').with(group: 'kafka',
+                                                  shell: '/bin/bash',
+                                                  home: '/home/kafka')
+  end
+end


### PR DESCRIPTION
this is followup from #39 - I included the kafka user configuration in the `_user_group` recipe, which would call `service[kafka]` before chef-client was aware of the service.